### PR TITLE
Handle expired authentication token error to sign out

### DIFF
--- a/Kedi/Screens/Settings/Main/SettingsViewModel.swift
+++ b/Kedi/Screens/Settings/Main/SettingsViewModel.swift
@@ -137,6 +137,10 @@ final class SettingsViewModel: ObservableObject {
             meManager.signOut()
         } catch {
             errorAlert = error
+
+            if let rcError = error as? RCError, rcError.signOutAutomatically {
+                meManager.signOut()
+            }
         }
     }
     

--- a/Shared/Network/Models/Error/RCError.swift
+++ b/Shared/Network/Models/Error/RCError.swift
@@ -32,6 +32,13 @@ enum RCError: Error {
         default: self = .unknown(error)
         }
     }
+
+    var signOutAutomatically: Bool {
+        switch self {
+        case .expiredAuthorizationToken: true
+        default: false
+        }
+    }
 }
 
 extension RCError: LocalizedError {


### PR DESCRIPTION
![IMG_9172](https://github.com/sereisoglu/Kedi/assets/26348933/a1cd55da-f793-4dd9-825b-7998e50b7b4c) ![IMG_9173](https://github.com/sereisoglu/Kedi/assets/26348933/7df46aff-3d85-48e1-9542-db44a69a1331)

I encountered this problem in the app. When I change my credentials on the RevenueCat website the Kedi app does not allow me to sign out. I have checked and added the expired token error handling to allow sign out, at least, when the user presses the sign out button.

I think you would have to develop an intermediate layer between the viewmodel and the API class, to handle this error in the whole app.