### PR TITLE
Added App Store pay dates for 2025

### DIFF
--- a/Kedi/Screens/Settings/Payday/PaydayScreen.swift
+++ b/Kedi/Screens/Settings/Payday/PaydayScreen.swift
@@ -49,7 +49,7 @@ struct PaydayScreen: View {
                 }
             }
             
-            ForEach(Array(viewModel.paydays.keys.sorted()), id: \.self) { year in
+            ForEach(Array(viewModel.paydays.keys.reversed()), id: \.self) { year in
                 Section {
                     ForEach(viewModel.paydays[year] ?? []) { payday in
                         makeItem(

--- a/Kedi/Screens/Settings/Payday/PaydayScreen.swift
+++ b/Kedi/Screens/Settings/Payday/PaydayScreen.swift
@@ -49,7 +49,7 @@ struct PaydayScreen: View {
                 }
             }
             
-            ForEach(Array(viewModel.paydays.keys.reversed()), id: \.self) { year in
+            ForEach(Array(viewModel.sortedYears), id: \.self) { year in
                 Section {
                     ForEach(viewModel.paydays[year] ?? []) { payday in
                         makeItem(

--- a/Kedi/Screens/Settings/Payday/PaydayViewModel.swift
+++ b/Kedi/Screens/Settings/Payday/PaydayViewModel.swift
@@ -11,9 +11,11 @@ final class PaydayViewModel: ObservableObject {
     
     let upcomingPayday: AppStorePayday?
     let paydays: [Int: [AppStorePayday]]
+    let sortedYears: [Int]
     
     init() {
         upcomingPayday = AppStorePayday.upcomingPayday
         paydays = .init(grouping: AppStorePayday.paydays, by: { $0.fiscalYear })
+        sortedYears = paydays.keys.sorted(by: >)
     }
 }

--- a/Shared/Models/AppStorePayday.swift
+++ b/Shared/Models/AppStorePayday.swift
@@ -156,90 +156,6 @@ extension AppStorePayday {
         let string = #"""
         [
             {
-                "fiscalYear": 2024,
-                "fiscalMonth": "2023-10",
-                "startDate": "2023-10-01",
-                "endDate": "2023-11-04",
-                "paymentDate": "2023-12-07"
-            },
-            {
-                "fiscalYear": 2024,
-                "fiscalMonth": "2023-11",
-                "startDate": "2023-11-05",
-                "endDate": "2023-12-02",
-                "paymentDate": "2024-01-04"
-            },
-            {
-                "fiscalYear": 2024,
-                "fiscalMonth": "2023-12",
-                "startDate": "2023-12-03",
-                "endDate": "2023-12-30",
-                "paymentDate": "2024-02-01"
-            },
-            {
-                "fiscalYear": 2024,
-                "fiscalMonth": "2024-01",
-                "startDate": "2023-12-31",
-                "endDate": "2024-02-03",
-                "paymentDate": "2024-03-07"
-            },
-            {
-                "fiscalYear": 2024,
-                "fiscalMonth": "2024-02",
-                "startDate": "2024-02-04",
-                "endDate": "2024-03-02",
-                "paymentDate": "2024-04-04"
-            },
-            {
-                "fiscalYear": 2024,
-                "fiscalMonth": "2024-03",
-                "startDate": "2024-03-03",
-                "endDate": "2024-03-30",
-                "paymentDate": "2024-05-02"
-            },
-            {
-                "fiscalYear": 2024,
-                "fiscalMonth": "2024-04",
-                "startDate": "2024-03-31",
-                "endDate": "2024-05-04",
-                "paymentDate": "2024-06-06"
-            },
-            {
-                "fiscalYear": 2024,
-                "fiscalMonth": "2024-05",
-                "startDate": "2024-05-05",
-                "endDate": "2024-06-01",
-                "paymentDate": "2024-07-04"
-            },
-            {
-                "fiscalYear": 2024,
-                "fiscalMonth": "2024-06",
-                "startDate": "2024-06-02",
-                "endDate": "2024-06-29",
-                "paymentDate": "2024-08-01"
-            },
-            {
-                "fiscalYear": 2024,
-                "fiscalMonth": "2024-07",
-                "startDate": "2024-06-30",
-                "endDate": "2024-08-03",
-                "paymentDate": "2024-09-05"
-            },
-            {
-                "fiscalYear": 2024,
-                "fiscalMonth": "2024-08",
-                "startDate": "2024-08-04",
-                "endDate": "2024-08-31",
-                "paymentDate": "2024-10-03"
-            },
-            {
-                "fiscalYear": 2024,
-                "fiscalMonth": "2024-09",
-                "startDate": "2024-09-01",
-                "endDate": "2024-09-28",
-                "paymentDate": "2024-10-31"
-            },
-            {
                 "fiscalYear": 2025,
                 "fiscalMonth": "2024-10",
                 "startDate": "2024-09-29",
@@ -266,6 +182,62 @@ extension AppStorePayday {
                 "startDate": "2024-12-29",
                 "endDate": "2025-02-01",
                 "paymentDate": "2025-03-06"
+            },
+            {
+                "fiscalYear": 2025,
+                "fiscalMonth": "2025-02",
+                "startDate": "2025-02-02",
+                "endDate": "2025-03-01",
+                "paymentDate": "2025-04-03"
+            },
+            {
+                "fiscalYear": 2025,
+                "fiscalMonth": "2025-03",
+                "startDate": "2025-03-02",
+                "endDate": "2025-03-29",
+                "paymentDate": "2025-05-01"
+            },
+            {
+                "fiscalYear": 2025,
+                "fiscalMonth": "2025-04",
+                "startDate": "2025-03-30",
+                "endDate": "2025-05-03",
+                "paymentDate": "2025-06-05"
+            },
+            {
+                "fiscalYear": 2025,
+                "fiscalMonth": "2025-05",
+                "startDate": "2025-05-04",
+                "endDate": "2025-05-31",
+                "paymentDate": "2025-07-03"
+            },
+            {
+                "fiscalYear": 2025,
+                "fiscalMonth": "2025-06",
+                "startDate": "2025-06-01",
+                "endDate": "2025-06-28",
+                "paymentDate": "2025-07-31"
+            },
+            {
+                "fiscalYear": 2025,
+                "fiscalMonth": "2025-07",
+                "startDate": "2025-06-29",
+                "endDate": "2025-08-02",
+                "paymentDate": "2025-09-04"
+            },
+            {
+                "fiscalYear": 2025,
+                "fiscalMonth": "2025-08",
+                "startDate": "2025-08-03",
+                "endDate": "2025-08-20",
+                "paymentDate": "2025-10-02"
+            },
+            {
+                "fiscalYear": 2025,
+                "fiscalMonth": "2025-09",
+                "startDate": "2025-08-31",
+                "endDate": "2025-09-27",
+                "paymentDate": "2025-10-30"
             }
         ]
         """#

--- a/Shared/Models/AppStorePayday.swift
+++ b/Shared/Models/AppStorePayday.swift
@@ -156,6 +156,90 @@ extension AppStorePayday {
         let string = #"""
         [
             {
+                "fiscalYear": 2024,
+                "fiscalMonth": "2023-10",
+                "startDate": "2023-10-01",
+                "endDate": "2023-11-04",
+                "paymentDate": "2023-12-07"
+            },
+            {
+                "fiscalYear": 2024,
+                "fiscalMonth": "2023-11",
+                "startDate": "2023-11-05",
+                "endDate": "2023-12-02",
+                "paymentDate": "2024-01-04"
+            },
+            {
+                "fiscalYear": 2024,
+                "fiscalMonth": "2023-12",
+                "startDate": "2023-12-03",
+                "endDate": "2023-12-30",
+                "paymentDate": "2024-02-01"
+            },
+            {
+                "fiscalYear": 2024,
+                "fiscalMonth": "2024-01",
+                "startDate": "2023-12-31",
+                "endDate": "2024-02-03",
+                "paymentDate": "2024-03-07"
+            },
+            {
+                "fiscalYear": 2024,
+                "fiscalMonth": "2024-02",
+                "startDate": "2024-02-04",
+                "endDate": "2024-03-02",
+                "paymentDate": "2024-04-04"
+            },
+            {
+                "fiscalYear": 2024,
+                "fiscalMonth": "2024-03",
+                "startDate": "2024-03-03",
+                "endDate": "2024-03-30",
+                "paymentDate": "2024-05-02"
+            },
+            {
+                "fiscalYear": 2024,
+                "fiscalMonth": "2024-04",
+                "startDate": "2024-03-31",
+                "endDate": "2024-05-04",
+                "paymentDate": "2024-06-06"
+            },
+            {
+                "fiscalYear": 2024,
+                "fiscalMonth": "2024-05",
+                "startDate": "2024-05-05",
+                "endDate": "2024-06-01",
+                "paymentDate": "2024-07-04"
+            },
+            {
+                "fiscalYear": 2024,
+                "fiscalMonth": "2024-06",
+                "startDate": "2024-06-02",
+                "endDate": "2024-06-29",
+                "paymentDate": "2024-08-01"
+            },
+            {
+                "fiscalYear": 2024,
+                "fiscalMonth": "2024-07",
+                "startDate": "2024-06-30",
+                "endDate": "2024-08-03",
+                "paymentDate": "2024-09-05"
+            },
+            {
+                "fiscalYear": 2024,
+                "fiscalMonth": "2024-08",
+                "startDate": "2024-08-04",
+                "endDate": "2024-08-31",
+                "paymentDate": "2024-10-03"
+            },
+            {
+                "fiscalYear": 2024,
+                "fiscalMonth": "2024-09",
+                "startDate": "2024-09-01",
+                "endDate": "2024-09-28",
+                "paymentDate": "2024-10-31"
+            },
+            {
                 "fiscalYear": 2025,
                 "fiscalMonth": "2024-10",
                 "startDate": "2024-09-29",


### PR DESCRIPTION
![Simulator Screenshot - iPhone 16 Pro Max - 2025-02-14 at 15 26 25](https://github.com/user-attachments/assets/58ac511f-0543-424f-9be7-9b1f371ecd53) 
![CleanShot 2025-02-14 at 15 29 38@2x](https://github.com/user-attachments/assets/3749298b-2ed7-448b-9c84-f65cdc4f79ef)
**Resource:** https://www.revenuecat.com/blog/growth/apple-fiscal-calendar-year-payment-dates/
